### PR TITLE
Place conn.txt in config instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This is based on topic C, Stuff Sharing.
 
 ## Setting up postgresql
 1. Setup postgresql from the [official documentation](https://www.postgresql.org/docs/10/static/index.html) under chapter 16/17.
-1. Setup your `.pgpass` file for secure storage of password and port as explained [here](https://www.postgresql.org/docs/9.3/static/libpq-pgpass.html) or [this SO post](https://stackoverflow.com/questions/28800880/python-connect-to-postgresql-with-libpq-pgpass)  for linux/mac.
-1. Replace the dbname and username values for db/__init__.py in [line 24](https://github.com/vivekscl/CS2102-Project/blob/master/db/__init__.py#L24) and the username value in [line 32](https://github.com/vivekscl/CS2102-Project/blob/master/db/__init__.py#L32).
+1. Setup your `.pgpass` file for secure storage of password and port as explained [here](https://www.postgresql.org/docs/9.3/static/libpq-pgpass.html) or [this SO post](https://stackoverflow.com/questions/28800880/python-connect-to-postgresql-with-libpq-pgpass)  for Linux/Mac.
+1. Create a file called `conn.txt` which contains the connection string for the `psycopg2` library to connect to a postgresql server. This file will contain the parameters for the connection string. For example, `host='localhost' dbname='mydbname' user='myusername'`.
 
 ## Running the app
 1. Fork and then clone the repo.

--- a/config.py
+++ b/config.py
@@ -12,6 +12,7 @@ class Config:
     DEBUG = False
     TESTING = False
     SCHEMA_LOCATION = os.environ.get('DEV_SCHEMA_LOCATION', os.path.join(basedir, 'db/schema.sql'))
+    CONNECTION_FILE = open('conn.txt', 'r').read()
 
     @staticmethod
     def init_app(app):

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -21,15 +21,17 @@ class DatabaseCursor:
 
 
 def connect_db():
-    conn_string = open('conn.txt', 'r').read() # Get port and password from .pgpass file
+    conn_string = config[os.getenv("FLASK_CONFIG")].CONNECTION_FILE
     conn = psycopg2.connect(conn_string, cursor_factory=extras.DictCursor)
     return conn
 
 
 def init_db():
-    # Create database first if it doesn't exist
-    # postgres is the default db and can be used temporarily to interact with the db server and get useful info
-    conn_string = open('conn.txt', 'r').read()
+    """
+    Create database first if it doesn't exist
+    postgres is the default db and can be used temporarily to interact with the db server and get useful info
+    """
+    conn_string = config[os.getenv("FLASK_CONFIG")].CONNECTION_FILE
     conn = psycopg2.connect(conn_string)
 
     conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)


### PR DESCRIPTION
This allows the connection string to be detached from the project
files and also improves readability by removing "magic strings".